### PR TITLE
Make SPI mode configurable

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -128,6 +128,15 @@ config MIPI_DISPLAY_SPI_CLOCK_SPEED_HZ
     help
         SPI clock speed in Hz. If you have problems try a lower value.
 
+config MIPI_DISPLAY_SPI_MODE
+    int "SPI mode"
+    default 0
+    range 0 3
+    help
+        SPI mode representing the (CPOL, CPHA) configuration. Usually
+        you do not need to change this but some board without CS line
+        require mode 3.
+
 if IDF_TARGET_ESP32
 choice
     prompt "SPI HOST"
@@ -159,9 +168,7 @@ config MIPI_DISPLAY_SPI_HOST
     hex
     default 0x01 if ESP32S2_FSPI_HOST_SELECTED
     default 0x02 if ESP32S2_HSPI_HOST_SELECTED
-
 endif
-
 
 config MIPI_DISPLAY_PIN_MISO
     int "MISO pin number"

--- a/src/mipi_display.c
+++ b/src/mipi_display.c
@@ -128,7 +128,7 @@ static void mipi_display_spi_master_init(spi_device_handle_t *spi)
     };
     spi_device_interface_config_t devcfg = {
         .clock_speed_hz = CONFIG_MIPI_DISPLAY_SPI_CLOCK_SPEED_HZ,
-        .mode = 0,
+        .mode = CONFIG_MIPI_DISPLAY_SPI_MODE,
         .spics_io_num = CONFIG_MIPI_DISPLAY_PIN_CS,
         .queue_size = 64,
         .pre_cb = mipi_display_pre_callback,


### PR DESCRIPTION
Most of the time there is no need to touch this setting. However there seems to be some display boards which require adjusting this setting. For example the 240x240 ST7789 without CS pin seems to need mode 3.

https://www.aliexpress.com/item/32867668144.html
