### PR TITLE
Enable Compiling with ESP-IDF V6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
+idf_build_get_property(idf_version IDF_VERSION_MAJOR)
+
+if(idf_version GREATER_EQUAL 6)
+    set(driver_dependencies esp_driver_spi esp_driver_ledc esp_driver_gpio)
+else()
+    set(driver_dependencies driver)
+endif()
+
 idf_component_register(
     SRCS "src/hagl_hal_single.c" "src/hagl_hal_double.c" "src/hagl_hal_triple.c" "src/mipi_display.c"
     INCLUDE_DIRS "./include"
-    REQUIRES hagl driver esp_driver_spi esp_driver_ledc esp_driver_gpio
+    REQUIRES hagl ${driver_dependencies}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "src/hagl_hal_single.c" "src/hagl_hal_double.c" "src/hagl_hal_triple.c" "src/mipi_display.c"
     INCLUDE_DIRS "./include"
-    REQUIRES hagl driver
+    REQUIRES hagl driver esp_driver_spi esp_driver_ledc esp_driver_gpio
 )


### PR DESCRIPTION
This PR adds compatibility with ESP-IDF v6.0 and newer versions while preserving backward compatibility with older ESP-IDF releases.

Starting with ESP-IDF v6.0, the legacy driver component no longer provides dependencies for peripherals such as SPI, GPIO, and LEDC. These dependencies must now be declared explicitly.

For additional details, see the ESP-IDF v6.0 Peripherals Migration Guide:

https://docs.espressif.com/projects/esp-idf/en/stable/esp32/migration-guides/release-6.x/6.0/peripherals.html

## Changes

This PR introduces a version check in `CMakeLists.txt` and selects dependencies based on the detected ESP-IDF version.

* **ESP-IDF ≥ 6.0**

  * Explicitly declares dependencies on:

    * `esp_driver_spi`
    * `esp_driver_gpio`
    * `esp_driver_ledc`

* **ESP-IDF < 6.0**

  * Continues using the legacy `driver` component.

I have built and tested for `ESP-IDF v6.0.1`, and I believe it builds fine for versions <6.0 as well.